### PR TITLE
Small ui changes

### DIFF
--- a/Arrt/View/ArrtStyle.cpp
+++ b/Arrt/View/ArrtStyle.cpp
@@ -29,7 +29,7 @@ const QColor ArrtStyle::s_formControlFocusedColor = QColor(70, 70, 70);
 const QColor ArrtStyle::s_successColor = Qt::darkGreen;
 const QColor ArrtStyle::s_runningColor = Qt::darkYellow;
 const QColor ArrtStyle::s_failureColor = Qt::darkRed;
-const QColor ArrtStyle::s_progressBackgroundColor = Qt::lightGray;
+const QColor ArrtStyle::s_progressBackgroundColor = Qt::darkGray;
 const QColor ArrtStyle::s_progressColor = Qt::blue;
 
 const QColor ArrtStyle::s_connectedColor = Qt::green;

--- a/Arrt/View/BlobExplorer/BlobListView.cpp
+++ b/Arrt/View/BlobExplorer/BlobListView.cpp
@@ -88,15 +88,20 @@ public:
                     {
                         loadingProgress = 0;
                     }
+                    QFontMetrics fm(ArrtStyle::s_blobStatusFont, option.widget);
+                    int barheight = fm.height() / 3;
                     QPoint p1 = loadingUiRect.center();
                     QPoint p2 = p1;
-                    p2.setX(loadingUiRect.right());
-                    QPoint pProgress = p1 + (p2 - p1) * loadingProgress;
+                    p2.setX(loadingUiRect.right() - DpiUtils::size(10));
 
-                    painter->setPen(QPen(ArrtStyle::s_progressColor, 2));
-                    painter->drawLine(p1, pProgress);
-                    painter->setPen(QPen(ArrtStyle::s_progressBackgroundColor, 2));
-                    painter->drawLine(pProgress, p2);
+                    QRect progressRect(p1 - QPoint(0, barheight / 2), p2 + QPoint(0, barheight / 2));
+                    painter->fillRect(progressRect, ArrtStyle::s_progressBackgroundColor);
+                    QRect progressDoneRect = progressRect;
+                    progressDoneRect.setWidth(float(progressDoneRect.width()) * loadingProgress);
+                    painter->fillRect(progressDoneRect, ArrtStyle::s_progressColor);
+                    painter->setPen(option.palette.windowText().color());
+                    painter->setBrush(Qt::NoBrush);
+                    painter->drawRect(progressRect);
                     break;
             }
             textRect.setRight(loadingUiRect.left() - DpiUtils::size(5));

--- a/Arrt/View/ModelEditor/MaterialEditorView.cpp
+++ b/Arrt/View/ModelEditor/MaterialEditorView.cpp
@@ -11,9 +11,9 @@ MaterialEditorView::MaterialEditorView(MaterialProvider* model, QWidget* parent)
     : QWidget(parent)
     , m_model(model)
 {
+    setContentsMargins(0, 0, 0, 0);
     auto* scrollArea = new VerticalScrollArea(this);
     auto* l = new QVBoxLayout(this);
-    setContentsMargins(0, 0, 0, 0);
     l->setContentsMargins(0, 0, 0, 0);
     l->addWidget(scrollArea);
 

--- a/Arrt/View/ModelEditor/MaterialEditorView.cpp
+++ b/Arrt/View/ModelEditor/MaterialEditorView.cpp
@@ -8,23 +8,22 @@
 #include <Widgets/VerticalScrollArea.h>
 
 MaterialEditorView::MaterialEditorView(MaterialProvider* model, QWidget* parent)
-    : QWidget(parent)
+    : FocusableContainer({}, parent)
     , m_model(model)
 {
-    setContentsMargins(0, 0, 0, 0);
     auto* scrollArea = new VerticalScrollArea(this);
-    auto* l = new QVBoxLayout(this);
-    l->setContentsMargins(0, 0, 0, 0);
-    l->addWidget(scrollArea);
-
     m_layout = scrollArea->getContentLayout();
-    QObject::connect(m_model, &MaterialProvider::materialChanged, this, [this]() { updateFromModel(); });
-}
+    setChild(scrollArea);
 
+    QObject::connect(m_model, &MaterialProvider::materialChanged, this, [this]() { updateFromModel(); });
+    updateFromModel();
+}
 
 void MaterialEditorView::updateFromModel()
 {
     const auto& controls = m_model->getControls();
+    setVisible(!controls.empty());
+
     for (int i = 0; i < controls.size(); ++i)
     {
         if (m_widgets.size() == i)

--- a/Arrt/View/ModelEditor/MaterialEditorView.h
+++ b/Arrt/View/ModelEditor/MaterialEditorView.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <QWidget>
+#include <Widgets/FocusableContainer.h>
 
 class MaterialProvider;
 class ParameterModel;
@@ -7,7 +7,7 @@ class FormControl;
 
 // View for the property editor for the material, exposing all of the controls
 
-class MaterialEditorView : public QWidget
+class MaterialEditorView : public FocusableContainer
 {
 public:
     MaterialEditorView(MaterialProvider* model, QWidget* parent = nullptr);
@@ -15,7 +15,7 @@ public:
 private:
     MaterialProvider* const m_model;
     QList<FormControl*> m_widgets;
-    QLayout* m_layout;
+    QLayout* m_layout = {};
 
     // called when the control models have changed, to regenerate the controls
     void updateFromModel();

--- a/Arrt/View/ModelEditor/MaterialsList.cpp
+++ b/Arrt/View/ModelEditor/MaterialsList.cpp
@@ -6,7 +6,9 @@
 MaterialListView::MaterialListView(ModelEditorModel* model, QWidget* parent /* = nullptr */)
     : QWidget(parent)
 {
+    setContentsMargins(0, 0, 0, 0);
     auto* l = new QHBoxLayout(this);
+    l->setContentsMargins(0, 0, 0, 0);
     auto* listView = new QListView(this);
     listView->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
     listView->setModel(model->getMaterialListModel());

--- a/Arrt/View/ModelEditor/ModelEditorView.cpp
+++ b/Arrt/View/ModelEditor/ModelEditorView.cpp
@@ -100,7 +100,7 @@ ModelEditorView::ModelEditorView(ModelEditorModel* modelEditorModel)
 
         {
             auto* materialPanel = new MaterialEditorView(modelEditorModel->getEditingMaterial(), splitter);
-            splitter->addWidget(new FocusableContainer(materialPanel));
+            splitter->addWidget(materialPanel);
         }
 
         splitter->setSizes({10, 40, 10, 10});

--- a/Arrt/View/ModelEditor/ModelEditorView.cpp
+++ b/Arrt/View/ModelEditor/ModelEditorView.cpp
@@ -10,6 +10,7 @@
 #include <ViewModel/ModelEditor/ModelEditorModel.h>
 #include <ViewModel/ModelEditor/ViewportModel.h>
 #include <Widgets/FlatButton.h>
+#include <Widgets/FocusableContainer.h>
 
 // the viewport widget has to be wrapped by a non native widget with WA_DontCreateNativeAncestors set,
 // to make sure that the parent widgets won't be turned into native widgets. This is because this might break
@@ -21,6 +22,7 @@ public:
     ContainerForViewport(QWidget* parentWidget)
         : QWidget(parentWidget)
     {
+        setContentsMargins(0, 0, 0, 0);
         setAttribute(Qt::WA_DontCreateNativeAncestors);
         setAttribute(Qt::WA_LayoutOnEntireRect);
         setMinimumWidth(256);
@@ -75,25 +77,30 @@ ModelEditorView::ModelEditorView(ModelEditorModel* modelEditorModel)
         splitter = new QSplitter(this);
 
         {
-            auto scenePanel = new ScenePanelView(modelEditorModel, this);
-            splitter->addWidget(scenePanel);
+            auto scenePanel = new ScenePanelView(modelEditorModel, splitter);
+            splitter->addWidget(new FocusableContainer(scenePanel));
         }
 
         {
-            auto container = new ContainerForViewport(splitter);
-            auto viewportModel = new ViewportView(modelEditorModel->getViewportModel(), container);
+            auto* focusableContainer = new FocusableContainer({}, splitter);
+            auto* container = new ContainerForViewport(focusableContainer);
+            auto* viewportModel = new ViewportView(modelEditorModel->getViewportModel(), container);
             container->setViewport(viewportModel);
-            splitter->addWidget(container);
+
+            auto* viewportLayout = new QHBoxLayout(focusableContainer);
+            viewportLayout->setContentsMargins(0, 0, 0, 0);
+            viewportLayout->addWidget(container);
+            splitter->addWidget(focusableContainer);
         }
 
         {
-            auto materialPanel = new MaterialListView(modelEditorModel, this);
-            splitter->addWidget(materialPanel);
+            auto* materialPanel = new MaterialListView(modelEditorModel, splitter);
+            splitter->addWidget(new FocusableContainer(materialPanel));
         }
 
         {
-            auto materialPanel = new MaterialEditorView(modelEditorModel->getEditingMaterial(), this);
-            splitter->addWidget(materialPanel);
+            auto* materialPanel = new MaterialEditorView(modelEditorModel->getEditingMaterial(), splitter);
+            splitter->addWidget(new FocusableContainer(materialPanel));
         }
 
         splitter->setSizes({10, 40, 10, 10});

--- a/Arrt/View/ModelEditor/ScenePanelView.cpp
+++ b/Arrt/View/ModelEditor/ScenePanelView.cpp
@@ -7,6 +7,7 @@ ScenePanelView::ScenePanelView(ModelEditorModel* model, QWidget* parent /* = nul
     : QWidget(parent)
 {
     auto* l = new QHBoxLayout(this);
+    l->setContentsMargins(0, 0, 0, 0);
     auto* treeView = new QTreeView(this);
     treeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     treeView->setHeaderHidden(true);

--- a/Arrt/Widgets/FocusableContainer.cpp
+++ b/Arrt/Widgets/FocusableContainer.cpp
@@ -54,12 +54,17 @@ FocusableContainer::FocusableContainer(QWidget* childWidget, QWidget* parent)
     setContentsMargins(1, 1, 1, 1);
     if (childWidget)
     {
-        auto* l = new QHBoxLayout(this);
-        l->setContentsMargins(0, 0, 0, 0);
-        l->addWidget(childWidget);
+        setChild(childWidget);
     }
 }
 
+void FocusableContainer::setChild(QWidget* child)
+{
+    assert(child);
+    auto* l = new QHBoxLayout(this);
+    l->setContentsMargins(0, 0, 0, 0);
+    l->addWidget(child);
+}
 
 
 QObject* FocusableContainer::installFocusListener(QApplication* application)

--- a/Arrt/Widgets/FocusableContainer.h
+++ b/Arrt/Widgets/FocusableContainer.h
@@ -10,6 +10,9 @@ class FocusableContainer : public QWidget
 public:
     FocusableContainer(QWidget* childWidget = {}, QWidget* parent = {});
 
+    // set the child in this container. Child has to be non null and this method can only be called once
+    void setChild(QWidget* child);
+
     static QObject* installFocusListener(QApplication* application);
 
     virtual void paintEvent(QPaintEvent* e) override;


### PR DESCRIPTION
See commit messages
See: loading a model has a better progress bar.
![image](https://user-images.githubusercontent.com/54460115/87304310-84696300-c50c-11ea-9c6b-8a39eba92d5a.png)
See: material property editor is not shown when no material is selected. Also, the alignment of the panels is improved and the focused panel has a highlighted border
![image](https://user-images.githubusercontent.com/54460115/87304342-921ee880-c50c-11ea-86fd-115a3ecf1dc8.png)
