### PR TITLE
Zoom on entity on model load and on entity double click

### DIFF
--- a/Arrt/View/ModelEditor/ScenePanelView.cpp
+++ b/Arrt/View/ModelEditor/ScenePanelView.cpp
@@ -5,6 +5,7 @@
 
 ScenePanelView::ScenePanelView(ModelEditorModel* model, QWidget* parent /* = nullptr */)
     : QWidget(parent)
+    , m_model(model)
 {
     auto* l = new QHBoxLayout(this);
     l->setContentsMargins(0, 0, 0, 0);
@@ -14,16 +15,21 @@ ScenePanelView::ScenePanelView(ModelEditorModel* model, QWidget* parent /* = nul
     treeView->setModel(model->getSceneTreeModel());
     treeView->setSelectionModel(model->getSceneTreeSelection());
 
-    QObject::connect(model->getSceneTreeSelection(), &QItemSelectionModel::selectionChanged, this,
-                     [treeView](const QItemSelection& selected, const QItemSelection& /*deselected*/) {
-                         // Make sure when an item is selected, it is visible.
-                         // This will expand the tree if the item is in a collapsed branch
-                         // and scroll the view, if needed
-                         QModelIndexList indices = selected.indexes();
-                         if (!indices.empty())
-                         {
-                             treeView->scrollTo(indices[0]);
-                         }
-                     });
+    connect(model->getSceneTreeSelection(), &QItemSelectionModel::selectionChanged, this,
+            [treeView](const QItemSelection& selected, const QItemSelection& /*deselected*/) {
+                // Make sure when an item is selected, it is visible.
+                // This will expand the tree if the item is in a collapsed branch
+                // and scroll the view, if needed
+                QModelIndexList indices = selected.indexes();
+                if (!indices.empty())
+                {
+                    treeView->scrollTo(indices[0]);
+                }
+            });
+    connect(treeView, &QTreeView::doubleClicked, this,
+            [this](const QModelIndex& index) {
+                m_model->focusEntity(index);
+            });
+
     l->addWidget(treeView);
 }

--- a/Arrt/View/ModelEditor/ScenePanelView.h
+++ b/Arrt/View/ModelEditor/ScenePanelView.h
@@ -10,4 +10,7 @@ class ScenePanelView : public QWidget
 {
 public:
     ScenePanelView(ModelEditorModel* model, QWidget* parent = nullptr);
+
+private:
+    ModelEditorModel* const m_model;
 };

--- a/Arrt/View/ModelEditor/ViewportView.cpp
+++ b/Arrt/View/ModelEditor/ViewportView.cpp
@@ -141,6 +141,14 @@ void ViewportView::mouseMoveEvent(QMouseEvent* event)
     }
 }
 
+void ViewportView::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton)
+    {
+        m_viewportModel->doubleClick(event->localPos().x(), event->localPos().y());
+    }
+}
+
 void ViewportView::updateFromKeyboard()
 {
     m_cameraForwardSpeed = 0.0f;

--- a/Arrt/View/ModelEditor/ViewportView.h
+++ b/Arrt/View/ModelEditor/ViewportView.h
@@ -24,6 +24,7 @@ protected:
     virtual bool event(QEvent* event) override;
     virtual void mousePressEvent(QMouseEvent* event) override;
     virtual void mouseMoveEvent(QMouseEvent* event) override;
+    virtual void mouseDoubleClickEvent(QMouseEvent* event) override;
     virtual void keyPressEvent(QKeyEvent* event) override;
     virtual void keyReleaseEvent(QKeyEvent* event) override;
 

--- a/ArrtModel/Model/ArrSessionManager.cpp
+++ b/ArrtModel/Model/ArrSessionManager.cpp
@@ -153,7 +153,7 @@ ArrSessionManager::ArrSessionManager(ArrFrontend* frontEnd, Configuration* confi
 
     try
     {
-        m_viewportModel = new ViewportModel(m_configuration->getVideoSettings(), m_configuration->getCameraSettings(), this);
+        m_viewportModel = new ViewportModel(m_configuration->getVideoSettings(), m_configuration->getCameraSettings(), this, this);
     }
     catch (...)
     {

--- a/ArrtModel/Model/ModelEditor/EntitySelection.cpp
+++ b/ArrtModel/Model/ModelEditor/EntitySelection.cpp
@@ -115,3 +115,8 @@ void EntitySelection::setSelection(const QList<RR::ApiHandle<RR::Entity>>& newSe
     }
     selectionChanged(justSelected, justDeselected);
 }
+
+void EntitySelection::focusEntity(const RR::ApiHandle<RR::Entity>& entity)
+{
+    Q_EMIT entityFocused(entity);
+}

--- a/ArrtModel/Model/ModelEditor/EntitySelection.h
+++ b/ArrtModel/Model/ModelEditor/EntitySelection.h
@@ -21,15 +21,19 @@ public:
     void select(const RR::ApiHandle<RR::Entity>& object, SelectionType type = SelectionType::SelectExclusively);
     void deselect(const RR::ApiHandle<RR::Entity>& object);
     void deselectAll();
-
     void setSelection(const QList<RR::ApiHandle<RR::Entity>>& newSelection);
 
     QSet<RR::ApiHandle<RR::Entity>>::const_iterator begin() const;
     QSet<RR::ApiHandle<RR::Entity>>::const_iterator end() const;
 
+    // called when an element is double clicked
+    void focusEntity(const RR::ApiHandle<RR::Entity>& entity);
+
 Q_SIGNALS:
     // notification that the selection has changed
     void selectionChanged(QList<RR::ApiHandle<RR::Entity>> m_added, QList<RR::ApiHandle<RR::Entity>> m_removed);
+    // when an entity get focused
+    void entityFocused(RR::ApiHandle<RR::Entity> focused);
 
 private:
     QSet<RR::ApiHandle<RR::Entity>> m_selected;

--- a/ArrtModel/ViewModel/ModelEditor/ModelEditorModel.cpp
+++ b/ArrtModel/ViewModel/ModelEditor/ModelEditorModel.cpp
@@ -120,6 +120,12 @@ QItemSelectionModel* ModelEditorModel::getSceneTreeSelection() const
     return m_treeSelectionModel;
 }
 
+void ModelEditorModel::focusEntity(QModelIndex entity) const
+{
+    RR::ApiHandle<RR::Entity> entityHandle = m_sceneTreeModel->getEntityFromIndex(entity);
+    m_entitySelection->focusEntity(entityHandle);
+}
+
 QAbstractItemModel* ModelEditorModel::getMaterialListModel() const
 {
     return m_materialListModel;

--- a/ArrtModel/ViewModel/ModelEditor/ModelEditorModel.h
+++ b/ArrtModel/ViewModel/ModelEditor/ModelEditorModel.h
@@ -23,6 +23,7 @@ public:
 
     QAbstractItemModel* getSceneTreeModel() const;
     QItemSelectionModel* getSceneTreeSelection() const;
+    void focusEntity(QModelIndex entity) const;
 
     QAbstractItemModel* getMaterialListModel() const;
     QItemSelectionModel* getMaterialListSelectionModel() const;

--- a/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
+++ b/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
@@ -20,6 +20,7 @@ class ViewportView;
 class EntitySelection;
 class CameraSettings;
 class VideoSettings;
+class ArrSessionManager;
 
 namespace Microsoft::Azure::RemoteRendering::Internal
 {
@@ -79,7 +80,7 @@ class ViewportModel : public QObject
     Q_OBJECT
 
 public:
-    ViewportModel(VideoSettings* videoSettings, CameraSettings* cameraSettings, QObject* parent);
+    ViewportModel(VideoSettings* videoSettings, CameraSettings* cameraSettings, ArrSessionManager* sessionManager, QObject* parent);
     virtual ~ViewportModel();
 
     void setSession(RR::ApiHandle<RR::AzureSession> session);
@@ -130,8 +131,9 @@ private:
     int m_width = 0;
     int m_height = 0;
 
-    CameraSettings* m_cameraSettings = nullptr;
-    VideoSettings* m_videoSettings = nullptr;
+    CameraSettings* const m_cameraSettings;
+    VideoSettings* const m_videoSettings;
+    ArrSessionManager* const m_sessionManager;
 
     QTimer* m_refreshTimer = nullptr;
 
@@ -164,6 +166,7 @@ private:
     QMatrix4x4 m_perspectiveMatrixInverse;
     QMatrix4x4 m_viewMatrixInverse;
     QVector3D m_cameraPosition;
+
     float m_yaw = 0.0f;   //yaw in radians
     float m_pitch = 0.0f; //pitch in radians
 
@@ -185,6 +188,8 @@ private:
 
     // handles click and double click
     void pick(int x, int y, bool doubleClick);
+
+    void setRotation(float yaw, float pitch);
 
     // Moves the camera to frame the entity
     void zoomOnEntity(RR::ApiHandle<RR::Entity> entity);

--- a/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
+++ b/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
@@ -188,4 +188,7 @@ private:
 
     // Moves the camera to frame the entity
     void zoomOnEntity(RR::ApiHandle<RR::Entity> entity);
+
+    // Moves the camera to frame a bounding box
+    void zoomOnBoundingBox(const QVector3D& minBB, const QVector3D& maxBB);
 };

--- a/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
+++ b/ArrtModel/ViewModel/ModelEditor/ViewportModel.h
@@ -95,6 +95,8 @@ public:
 
     void pick(int x, int y);
 
+    void doubleClick(int x, int y);
+
     void render();
 
     void setSelectionModel(EntitySelection* selectionModel);
@@ -180,4 +182,10 @@ private:
     void deinitializeD3D();
 
     void updateProxyTextures();
+
+    // handles click and double click
+    void pick(int x, int y, bool doubleClick);
+
+    // Moves the camera to frame the entity
+    void zoomOnEntity(RR::ApiHandle<RR::Entity> entity);
 };


### PR DESCRIPTION
Added double click binding on viewport and scene tree, which is handled by the entity selection and subscribed by the viewport model to change the camera
Zoom on bounding box
Camera is centered on the model when model is loaded