### PR TITLE
Reuse last output container/directory for new conversion

### DIFF
--- a/ArrtModel/Model/ArrFrontend.cpp
+++ b/ArrtModel/Model/ArrFrontend.cpp
@@ -14,7 +14,7 @@ ArrFrontend::ArrFrontend(QObject* parent)
     ci.up = RR::Axis::Y;
     ci.forward = RR::Axis::Z;
     ci.unitsPerMeter = 1.0F;
-    ci.toolId = std::string("ARRT." ARRT_VERSION );
+    ci.toolId = std::string("ARRT." ARRT_VERSION);
     RR::StartupRemoteRendering(ci);
 }
 

--- a/ArrtModel/Model/ConversionManager.h
+++ b/ArrtModel/Model/ConversionManager.h
@@ -11,6 +11,7 @@
 
 class AzureStorageManager;
 class ArrFrontend;
+class Configuration;
 
 // struct representing an conversion. It holds the current status and the parameters used (input/output)
 
@@ -133,7 +134,7 @@ class ConversionManager : public QObject
 public:
     typedef uint ConversionId;
 
-    ConversionManager(ArrFrontend* client, AzureStorageManager* storageManager, QObject* parent = nullptr);
+    ConversionManager(ArrFrontend* client, AzureStorageManager* storageManager, Configuration* configuration, QObject* parent = nullptr);
     ~ConversionManager();
 
     int getConversionsCount() const;
@@ -170,6 +171,8 @@ private:
     ArrFrontend* const m_frontend;
     // this is only needed to generate SAS from the input urls. <TODO> see if it can be removed
     AzureStorageManager* const m_storageManager;
+
+    Configuration* const m_configuration;
 
     // map from conversion ID to conversion data
     QMap<ConversionId, Conversion*> m_conversions;

--- a/ArrtModel/ViewModel/ApplicationModel.cpp
+++ b/ArrtModel/ViewModel/ApplicationModel.cpp
@@ -46,7 +46,7 @@ ApplicationModel::ApplicationModel()
     m_logModel = new LogModel(m_configuration, this);
     m_frontend = new ArrFrontend(this);
     m_storageManager = new AzureStorageManager(this);
-    m_conversionManager = new ConversionManager(m_frontend, m_storageManager, this);
+    m_conversionManager = new ConversionManager(m_frontend, m_storageManager, m_configuration, this);
     m_sessionManager = new ArrSessionManager(m_frontend, m_configuration, this);
     m_renderPageModel = new RenderPageModel(m_storageManager, m_sessionManager, m_configuration, this);
     m_uploadModel = new UploadModel(m_storageManager, m_configuration, this);

--- a/ArrtModel/ViewModel/Conversion/OutputSelectionModel.cpp
+++ b/ArrtModel/ViewModel/Conversion/OutputSelectionModel.cpp
@@ -10,8 +10,8 @@ OutputSelectionModel::OutputSelectionModel(AzureStorageManager* storageManager, 
     : QObject(parent)
     , m_storageManager(storageManager)
     , m_configuration(configuration)
-    , m_containersModel(new BlobContainerSelectorModel(storageManager, defaultContainer(std::move(container)), ConversionManager::s_default_output_container, true, this))
-    , m_explorerModel(new BlobExplorerModel(storageManager, m_containersModel->getCurrentContainer(), defaultDirectory(std::move(directory)), this))
+    , m_containersModel(new BlobContainerSelectorModel(storageManager, container, ConversionManager::s_default_output_container, true, this))
+    , m_explorerModel(new BlobExplorerModel(storageManager, m_containersModel->getCurrentContainer(), directory, this))
 {
     auto filterType = m_configuration->getUiState(QLatin1Literal("outputSelection:filterType"), BlobsListModel::FilterType::OnlySubDirectories);
     m_explorerModel->getBlobsModel()->setFilterType(filterType);
@@ -20,31 +20,6 @@ OutputSelectionModel::OutputSelectionModel(AzureStorageManager* storageManager, 
         m_explorerModel->setContainer(m_containersModel->getCurrentContainer());
     });
 }
-
-QString OutputSelectionModel::defaultContainer(QString container) const
-{
-    if (container.isEmpty())
-    {
-        return m_configuration->getUiState(QLatin1Literal("outputSelection:defaultContainer"), QString());
-    }
-    else
-    {
-        return container;
-    }
-}
-
-QString OutputSelectionModel::defaultDirectory(QString directory) const
-{
-    if (directory.isEmpty())
-    {
-        return m_configuration->getUiState(QLatin1Literal("outputSelection:defaultDirectory"), QString());
-    }
-    else
-    {
-        return directory;
-    }
-}
-
 
 OutputSelectionModel::~OutputSelectionModel()
 {

--- a/ArrtModel/ViewModel/Conversion/OutputSelectionModel.h
+++ b/ArrtModel/ViewModel/Conversion/OutputSelectionModel.h
@@ -33,7 +33,4 @@ private:
     Configuration* const m_configuration;
     BlobContainerSelectorModel* const m_containersModel;
     BlobExplorerModel* const m_explorerModel;
-
-    QString defaultContainer(QString container) const;
-    QString defaultDirectory(QString directory) const;
 };


### PR DESCRIPTION
Output container/directory for new conversions is taken from last one used, instead of being set to the default