### PR TITLE
Correctly display the number of polygons being rendered.

### DIFF
--- a/ArrtModel/Model/ArrServiceStats.cpp
+++ b/ArrtModel/Model/ArrServiceStats.cpp
@@ -58,7 +58,7 @@ void ArrServiceStats::updateStats(RR::ApiHandle<RR::AzureSession> session)
             m_currentStats.m_memoryCPU.addValue(m_lastPerformanceAssessment.memoryCPU.aggregate, m_tick);
             m_currentStats.m_memoryGPU.addValue(m_lastPerformanceAssessment.memoryGPU.aggregate, m_tick);
             m_currentStats.m_networkLatency.addValue(m_lastPerformanceAssessment.networkLatency.aggregate, m_tick);
-            m_currentStats.m_polygonsRendered.addValue(m_lastPerformanceAssessment.networkLatency.aggregate, m_tick);
+            m_currentStats.m_polygonsRendered.addValue(m_lastPerformanceAssessment.polygonsRendered.aggregate, m_tick);
             m_runningPerformanceAssesment = {};
         }
         else


### PR DESCRIPTION
Fix a copy/paste typo that caused the network latency to be used as the number of polygons being rendered.