### PR TITLE
Remove erroneous memset()s

### DIFF
--- a/ArrtModel/Model/ArrFrontend.cpp
+++ b/ArrtModel/Model/ArrFrontend.cpp
@@ -6,8 +6,7 @@
 ArrFrontend::ArrFrontend(QObject* parent)
     : QObject(parent)
 {
-    RR::RemoteRenderingInitialization ci;
-    memset(&ci, 0, sizeof(RR::RemoteRenderingInitialization));
+    RR::RemoteRenderingInitialization ci{};
     ci.connectionType = RR::ConnectionType::General;
     ci.graphicsApi = RR::GraphicsApiType::SimD3D11;
     ci.right = RR::Axis::X;
@@ -55,8 +54,7 @@ void ArrFrontend::connect()
     {
         setStatus(AccountConnectionStatus::CheckingCredentials);
 
-        RR::AzureFrontendAccountInfo fi;
-        memset(&fi, 0, sizeof(RR::AzureFrontendAccountInfo));
+        RR::AzureFrontendAccountInfo fi{};
         fi.AccountDomain = m_region;
         fi.AccountId = m_accountId;
         fi.AccountKey = m_accountKey;

--- a/ArrtModel/Model/ArrSessionManager.cpp
+++ b/ArrtModel/Model/ArrSessionManager.cpp
@@ -815,8 +815,7 @@ RR::Result ArrSessionManager::loadModelAsync(const QString& modelName, const cha
 
         qInfo(LoggingCategory::renderingSession)
             << tr("Requesting loading of model %1 (SAS=%2)").arg(modelName).arg(assetSAS);
-        RR::LoadModelFromSASParams params;
-        memset(&params, 0, sizeof(RR::LoadModelFromSASParams));
+        RR::LoadModelFromSASParams params{};
         params.ModelUrl = assetSAS;
         if (auto loadModelAsync = api->LoadModelFromSASAsync(params))
         {

--- a/ArrtModel/Model/ConversionManager.cpp
+++ b/ArrtModel/Model/ConversionManager.cpp
@@ -211,8 +211,7 @@ ConversionManager::ConversionId ConversionManager::addNewConversion()
 {
     const ConversionId newConversionId = ++m_highestId;
 
-    arr_asset_conversion_input_sas_params info;
-    memset(&info, 0, sizeof(arr_asset_conversion_input_sas_params));
+    arr_asset_conversion_input_sas_params info{};
 
     auto* newConversion = new Conversion();
     newConversion->m_output_storage_account_name = QString::fromStdWString(m_storageManager->getAccountName()).toStdString();
@@ -266,8 +265,7 @@ void ConversionManager::startConversion(ConversionManager::ConversionId newConve
         });
     };
 
-    arr_asset_conversion_input_sas_params info;
-    memset(&info, 0, sizeof(arr_asset_conversion_input_sas_params));
+    arr_asset_conversion_input_sas_params info{};
 
     QString inputSasToken = QString::fromStdWString(storageManager->getSasToken(newConversion->m_inputContainer,
                                                                                 azure::storage::blob_shared_access_policy::read |


### PR DESCRIPTION
We shouldn't call memset to reset the structs since these can contain complex types (e.g. std::string) that can't be memset.