### PR TITLE
Fix a memory leak of controls by setting their parent properly.

### DIFF
--- a/ArrtModel/ViewModel/Settings/ArrAccountSettingsModel.cpp
+++ b/ArrtModel/ViewModel/Settings/ArrAccountSettingsModel.cpp
@@ -13,15 +13,15 @@ ArrAccountSettingsModel::ArrAccountSettingsModel(ArrAccountSettings* arrAccountS
     , m_frontend(frontend)
 {
     using namespace std::literals;
-    m_controls.push_back(new TextModel(tr("ID"), m_arrAccountSettings, "id"sv, true));
-    m_controls.push_back(new TextModel(tr("Key"), m_arrAccountSettings, "key"sv, true, true));
-    m_controls.push_back(new TextModel(tr("Account Domain"), m_arrAccountSettings, "accountDomain"sv, true));
+    addControl(new TextModel(tr("ID"), m_arrAccountSettings, "id"sv, true));
+    addControl(new TextModel(tr("Key"), m_arrAccountSettings, "key"sv, true, true));
+    addControl(new TextModel(tr("Account Domain"), m_arrAccountSettings, "accountDomain"sv, true));
     auto* regionModel = new ComboBoxModelFromMap(tr("Region"), m_arrAccountSettings, "region"sv);
     for (auto&& region : m_arrAccountSettings->getAvailableRegions())
     {
         regionModel->addEntry(region.m_label, QVariant::fromValue(region.m_domainUrl));
     }
-    m_controls.push_back(regionModel);
+    addControl(regionModel);
 
     connect(m_frontend, &ArrFrontend::onStatusChanged, this, [this]() {
         Q_EMIT updateUi();

--- a/ArrtModel/ViewModel/Settings/CameraSettingsModel.cpp
+++ b/ArrtModel/ViewModel/Settings/CameraSettingsModel.cpp
@@ -9,12 +9,12 @@ CameraSettingsModel::CameraSettingsModel(CameraSettings* cameraSettings, QObject
     , m_cameraSettings(cameraSettings)
 {
     using namespace std::literals;
-    m_controls.push_back(new FloatSliderModel(tr("Field of view (degrees)"), m_cameraSettings, "fovAngle"sv, CameraSettings::s_fovAngleMin, CameraSettings::s_fovAngleMax, 1000));
-    m_controls.push_back(new FloatSliderModel(tr("Camera inertia"), m_cameraSettings, "cameraInertia"sv, CameraSettings::s_cameraInertiaMin, CameraSettings::s_cameraInertiaMax, 256));
-    m_controls.push_back(new FloatSliderModel(tr("Camera speed"), m_cameraSettings, "cameraSpeed"sv, CameraSettings::s_cameraRotationSpeedMin, CameraSettings::s_cameraSpeedMax, 10000, true));
-    m_controls.push_back(new FloatSliderModel(tr("Camera rotation speed"), m_cameraSettings, "cameraRotationSpeed"sv, CameraSettings::s_cameraRotationSpeedMin, CameraSettings::s_cameraRotationSpeedMax, 10000, true));
-    m_controls.push_back(new FloatSliderModel(tr("Near plane"), m_cameraSettings, "nearPlane"sv, CameraSettings::s_planeMin, CameraSettings::s_planeMax, 10000, true, "%.5fm"));
-    m_controls.push_back(new FloatSliderModel(tr("Far plane"), m_cameraSettings, "farPlane"sv, CameraSettings::s_planeMin, CameraSettings::s_planeMax, 10000, true, "%.5fm"));
+    addControl(new FloatSliderModel(tr("Field of view (degrees)"), m_cameraSettings, "fovAngle"sv, CameraSettings::s_fovAngleMin, CameraSettings::s_fovAngleMax, 1000));
+    addControl(new FloatSliderModel(tr("Camera inertia"), m_cameraSettings, "cameraInertia"sv, CameraSettings::s_cameraInertiaMin, CameraSettings::s_cameraInertiaMax, 256));
+    addControl(new FloatSliderModel(tr("Camera speed"), m_cameraSettings, "cameraSpeed"sv, CameraSettings::s_cameraRotationSpeedMin, CameraSettings::s_cameraSpeedMax, 10000, true));
+    addControl(new FloatSliderModel(tr("Camera rotation speed"), m_cameraSettings, "cameraRotationSpeed"sv, CameraSettings::s_cameraRotationSpeedMin, CameraSettings::s_cameraRotationSpeedMax, 10000, true));
+    addControl(new FloatSliderModel(tr("Near plane"), m_cameraSettings, "nearPlane"sv, CameraSettings::s_planeMin, CameraSettings::s_planeMax, 10000, true, "%.5fm"));
+    addControl(new FloatSliderModel(tr("Far plane"), m_cameraSettings, "farPlane"sv, CameraSettings::s_planeMin, CameraSettings::s_planeMax, 10000, true, "%.5fm"));
 
     m_globalScaleModel = new FloatSliderModel(tr("Global scale"), m_cameraSettings, "globalScale"sv, CameraSettings::s_scaleMin, CameraSettings::s_scaleMax, 10000, true, "%.5fm");
     m_autoGlobalScaleModel = new ToggleButtonModel(tr("Auto"), m_cameraSettings, "autoGlobalScale"sv);

--- a/ArrtModel/ViewModel/Settings/SettingsBaseModel.cpp
+++ b/ArrtModel/ViewModel/Settings/SettingsBaseModel.cpp
@@ -1,6 +1,13 @@
 #include <ViewModel/Settings/SettingsBaseModel.h>
+#include <ViewModel/Parameters/ParameterModel.h>
 
 SettingsBaseModel::SettingsBaseModel(QObject* parent)
     : QObject(parent)
 {
+}
+
+void SettingsBaseModel::addControl(ParameterModel* model)
+{
+    model->setParent(this);
+    m_controls.push_back(model);
 }

--- a/ArrtModel/ViewModel/Settings/SettingsBaseModel.h
+++ b/ArrtModel/ViewModel/Settings/SettingsBaseModel.h
@@ -10,6 +10,7 @@ class SettingsBaseModel : public QObject
 
 public:
     SettingsBaseModel(QObject* parent);
+
     const QList<ParameterModel*>& getControls() const { return m_controls; }
 
     virtual bool isEnabled() const = 0;
@@ -17,6 +18,10 @@ public:
 Q_SIGNALS:
     void updateUi();
 
+
 protected:
+    void addControl(ParameterModel* model);
+
+private:
     QList<ParameterModel*> m_controls;
 };

--- a/ArrtModel/ViewModel/Settings/StorageAccountSettingsModel.cpp
+++ b/ArrtModel/ViewModel/Settings/StorageAccountSettingsModel.cpp
@@ -11,9 +11,9 @@ StorageAccountSettingsModel::StorageAccountSettingsModel(AzureStorageAccountSett
     , m_storageManager(storageManager)
 {
     using namespace std::literals;
-    m_controls.push_back(new TextModel(tr("Name"), m_azureStorageAccountSettings, "name"sv, true));
-    m_controls.push_back(new TextModel(tr("Key"), m_azureStorageAccountSettings, "key"sv, true, true));
-    m_controls.push_back(new TextModel(tr("Blob endpoint (e.g. https://[s.a. name].blob.core.windows.net/)"), m_azureStorageAccountSettings, "blobEndpoint"sv, true));
+    addControl(new TextModel(tr("Name"), m_azureStorageAccountSettings, "name"sv, true));
+    addControl(new TextModel(tr("Key"), m_azureStorageAccountSettings, "key"sv, true, true));
+    addControl(new TextModel(tr("Blob endpoint (e.g. https://[s.a. name].blob.core.windows.net/)"), m_azureStorageAccountSettings, "blobEndpoint"sv, true));
 
     connect(m_storageManager, &AzureStorageManager::onStatusChanged, this, [this]() {
         Q_EMIT updateUi();

--- a/ArrtModel/ViewModel/Settings/VideoSettingsModel.cpp
+++ b/ArrtModel/ViewModel/Settings/VideoSettingsModel.cpp
@@ -14,9 +14,9 @@ VideoSettingsModel::VideoSettingsModel(VideoSettings* videoSettings, ArrSessionM
     m_pendingVideoSettings = new VideoSettings(this);
     *m_pendingVideoSettings = *m_videoSettings;
 
-    m_controls.push_back(new IntegerModel(tr("Horizontal resolution (pixels)"), m_pendingVideoSettings, "width"sv, VideoSettings::s_widthMin, VideoSettings::s_widthMax, VideoSettings::s_resolutionStep));
-    m_controls.push_back(new IntegerModel(tr("Vertical resolution (pixels)"), m_pendingVideoSettings, "height"sv, VideoSettings::s_heightMin, VideoSettings::s_heightMax, VideoSettings::s_resolutionStep));
-    m_controls.push_back(new IntegerModel(tr("Refresh rate (fps)"), m_pendingVideoSettings, "refreshRate"sv, VideoSettings::s_refreshRateMin, VideoSettings::s_refreshRateMax));
+    addControl(new IntegerModel(tr("Horizontal resolution (pixels)"), m_pendingVideoSettings, "width"sv, VideoSettings::s_widthMin, VideoSettings::s_widthMax, VideoSettings::s_resolutionStep));
+    addControl(new IntegerModel(tr("Vertical resolution (pixels)"), m_pendingVideoSettings, "height"sv, VideoSettings::s_heightMin, VideoSettings::s_heightMax, VideoSettings::s_resolutionStep));
+    addControl(new IntegerModel(tr("Refresh rate (fps)"), m_pendingVideoSettings, "refreshRate"sv, VideoSettings::s_refreshRateMin, VideoSettings::s_refreshRateMax));
 
     auto updateVideoSettings = [this]() {
         // Video settings can be configured only once before connecting to session runtime.


### PR DESCRIPTION
The parent of controls wasn't set leading to memory leaks.