### PR TITLE
Fix settings load

### DIFF
--- a/ArrtModel/Model/Settings/ArrAccountSettings.cpp
+++ b/ArrtModel/Model/Settings/ArrAccountSettings.cpp
@@ -76,7 +76,7 @@ void ArrAccountSettings::loadFromJson(const QJsonObject& arrAccountConfig)
         for (auto e : supportedAccountDomainsArray)
         {
             QJsonObject accountDomainObj = e.toObject();
-            ArrAccountSettings::AccountDomain accountDomain({accountDomainObj[QLatin1String("name")].toString(), accountDomainObj[QLatin1String("url")].toString()});
+            ArrAccountSettings::AccountDomain accountDomain({accountDomainObj[QLatin1String("name")].toString(), accountDomainObj[QLatin1String("accountDomain")].toString()});
             m_supportedAccountDomainsMap[accountDomain.m_accountDomain] = accountDomain;
         }
     }


### PR DESCRIPTION
The supportedAccountDomains array is serialized with a "url" property but is expected to have a "accountDomain" property on load. I chose to make load match save, so that existing files behave as was presumably intended.