### PR TITLE
De-duplicate material support and pdb generation in release builds

### DIFF
--- a/.pipelines/testchecklist.md
+++ b/.pipelines/testchecklist.md
@@ -3,7 +3,7 @@
 Test workflows to be done before any release.
 
 - Start application -> No crash.
-- Enter ARR and Storage account credentials -> The status changes to "connected"
+- Enter ARR and Storage account credentials -> The status changes to "Authenticated"
 
 ## Upload panel
 
@@ -112,7 +112,7 @@ Test workflows to be done before any release.
 - Open the Azure Storage Explorer and inspect the input blob container
 - Navigate to the input directory
 - Verify that a file "conversionSettings.json" is created besides the model file (also when the input root directory is set to a parent directory)
-- Verify that the file contains all of the values that were set in ARRT
+- Verify that the file contains all of the non-default values that were set in ARRT
   
 ## Rendering panel
 
@@ -120,7 +120,7 @@ Test workflows to be done before any release.
 
 - Click on the button "Render".
 - Verify that the controls are editable.
-- Select Max Time "00:10" and Automatic Extension as "00:10" (Auto make sure "Auto Extend" is pressed).
+- Select Max Time "00:10" and Automatic Extension as "00:10" (Also make sure "Auto Extend" is pressed).
 - Start session.
 - Verify that the Max Time and Extension Time are the ones you specified.
 - Check that the button now shows "Stop Session".
@@ -188,7 +188,7 @@ Test workflows to be done before any release.
   - The material list shows the union of the the materials in the selected entities. 
 - Select an entity from the viewport.
 - Select one of the materials from the material list.
-- Select the root node from the scene tree -> The selected material show stay selected, in the larger material list.
+- If you select a child entity and a material from it and then select the parent -> The selected material show stay selected, in the larger material list.
 - Modify the values from the material property editor on the right (for example the albedo color) -> observe the changes in the viewport immediately.
 
 ## Logs

--- a/ArrtModel/ViewModel/Conversion/ConversionConfigModel.cpp
+++ b/ArrtModel/ViewModel/Conversion/ConversionConfigModel.cpp
@@ -70,7 +70,7 @@ namespace
 
 bool ArrtConversion::Config::operator==(const Config& c) const
 {
-    return m_scaling == c.m_scaling && m_recenterToOrigin == c.m_recenterToOrigin && m_opaqueMaterialDefaultSidedness == c.m_opaqueMaterialDefaultSidedness && m_material_override == c.m_material_override && m_gammaToLinearMaterial == c.m_gammaToLinearMaterial && m_gammaToLinearVertex == c.m_gammaToLinearVertex && m_sceneGraphMode == c.m_sceneGraphMode && m_generateCollisionMesh == c.m_generateCollisionMesh && m_unlitMaterials == c.m_unlitMaterials && m_fbxAssumeMetallic == c.m_fbxAssumeMetallic && m_axis1 == c.m_axis1 && m_axis2 == c.m_axis2 && m_axis3 == c.m_axis3 && m_vertexPosition == c.m_vertexPosition && m_vertexColor0 == c.m_vertexColor0 && m_vertexColor1 == c.m_vertexColor1 && m_vertexNormal == c.m_vertexNormal && m_vertexTangent == c.m_vertexTangent && m_vertexBinormal == c.m_vertexBinormal && m_vertexTexCoord0 == c.m_vertexTexCoord0 && m_vertexTexCoord1 == c.m_vertexTexCoord1;
+    return m_scaling == c.m_scaling && m_recenterToOrigin == c.m_recenterToOrigin && m_opaqueMaterialDefaultSidedness == c.m_opaqueMaterialDefaultSidedness && m_material_override == c.m_material_override && m_gammaToLinearMaterial == c.m_gammaToLinearMaterial && m_gammaToLinearVertex == c.m_gammaToLinearVertex && m_sceneGraphMode == c.m_sceneGraphMode && m_generateCollisionMesh == c.m_generateCollisionMesh && m_unlitMaterials == c.m_unlitMaterials && m_fbxAssumeMetallic == c.m_fbxAssumeMetallic && m_deduplicateMaterials == c.m_deduplicateMaterials && m_axis1 == c.m_axis1 && m_axis2 == c.m_axis2 && m_axis3 == c.m_axis3 && m_vertexPosition == c.m_vertexPosition && m_vertexColor0 == c.m_vertexColor0 && m_vertexColor1 == c.m_vertexColor1 && m_vertexNormal == c.m_vertexNormal && m_vertexTangent == c.m_vertexTangent && m_vertexBinormal == c.m_vertexBinormal && m_vertexTexCoord0 == c.m_vertexTexCoord0 && m_vertexTexCoord1 == c.m_vertexTexCoord1;
 }
 
 bool ConversionConfigModel::isDefault() const
@@ -165,6 +165,7 @@ ConversionConfigModel::ConversionConfigModel(AzureStorageManager* storageManager
     m_controls.push_back(new CheckBoxModel(tr("Generate Collision Mesh"), this, "generateCollisionMesh"sv));
     m_controls.push_back(new CheckBoxModel(tr("Unlit Materials"), this, "unlitMaterials"sv));
     m_controls.push_back(new CheckBoxModel(tr("FBX Assume Metallic"), this, "fbxAssumeMetallic"sv));
+    m_controls.push_back(new CheckBoxModel(tr("De-duplicate Materials"), this, "deduplicateMaterials"sv));
     m_controls.push_back(new ComboBoxModelFromEnum(tr("Axis [0]"), this, "axis1"sv));
     m_controls.push_back(new ComboBoxModelFromEnum(tr("Axis [1]"), this, "axis2"sv));
     m_controls.push_back(new ComboBoxModelFromEnum(tr("Axis [2]"), this, "axis3"sv));
@@ -197,6 +198,7 @@ ArrtConversion::Config ConversionConfigModel::initFromJson(const QJsonDocument& 
         cfg.m_generateCollisionMesh = fromJson(root, QLatin1String("generateCollisionMesh"), cfg.m_generateCollisionMesh);
         cfg.m_unlitMaterials = fromJson(root, QLatin1String("unlitMaterials"), cfg.m_unlitMaterials);
         cfg.m_fbxAssumeMetallic = fromJson(root, QLatin1String("fbxAssumeMetallic"), cfg.m_fbxAssumeMetallic);
+        cfg.m_deduplicateMaterials = fromJson(root, QLatin1String("deduplicateMaterials"), cfg.m_deduplicateMaterials);
         auto axes = root[QLatin1String("axis")].toArray();
         cfg.m_axis1 = fromJson(axes, 0, cfg.m_axis1);
         cfg.m_axis2 = fromJson(axes, 1, cfg.m_axis2);
@@ -229,6 +231,7 @@ QJsonDocument ConversionConfigModel::createJson(const ArrtConversion::Config& co
         toJson(root, QLatin1String("generateCollisionMesh"), config.m_generateCollisionMesh, def.m_generateCollisionMesh);
         toJson(root, QLatin1String("unlitMaterials"), config.m_unlitMaterials, def.m_unlitMaterials);
         toJson(root, QLatin1String("fbxAssumeMetallic"), config.m_fbxAssumeMetallic, def.m_fbxAssumeMetallic);
+        toJson(root, QLatin1String("deduplicateMaterials"), config.m_deduplicateMaterials, def.m_deduplicateMaterials);
         QJsonArray axes;
         {
             bool hasValues = false;

--- a/ArrtModel/ViewModel/Conversion/ConversionConfigModel.h
+++ b/ArrtModel/ViewModel/Conversion/ConversionConfigModel.h
@@ -85,6 +85,7 @@ namespace ArrtConversion
         bool m_generateCollisionMesh = true;
         bool m_unlitMaterials = false;
         bool m_fbxAssumeMetallic = true;
+        bool m_deduplicateMaterials = true;
         Axis m_axis1 = Axis::PosX;
         Axis m_axis2 = Axis::PosY;
         Axis m_axis3 = Axis::PosZ;
@@ -95,7 +96,7 @@ namespace ArrtConversion
         VertexVector m_vertexTangent = VertexVector::ByteSx4N;
         VertexVector m_vertexBinormal = VertexVector::ByteSx4N;
         VertexTextureCoord m_vertexTexCoord0 = VertexTextureCoord::Float32x2;
-        VertexTextureCoord m_vertexTexCoord1 = VertexTextureCoord::None;
+        VertexTextureCoord m_vertexTexCoord1 = VertexTextureCoord::Float32x2;
     };
 } // namespace ArrtConversion
 
@@ -120,6 +121,7 @@ class ConversionConfigModel : public QObject, protected ArrtConversion::Config
     Q_PROPERTY(bool generateCollisionMesh MEMBER m_generateCollisionMesh);
     Q_PROPERTY(bool unlitMaterials MEMBER m_unlitMaterials);
     Q_PROPERTY(bool fbxAssumeMetallic MEMBER m_fbxAssumeMetallic);
+    Q_PROPERTY(bool deduplicateMaterials MEMBER m_deduplicateMaterials);
     Q_PROPERTY(ArrtConversion::Axis axis1 MEMBER m_axis1);
     Q_PROPERTY(ArrtConversion::Axis axis2 MEMBER m_axis2);
     Q_PROPERTY(ArrtConversion::Axis axis3 MEMBER m_axis3);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,11 @@ project(Arrt)
 
 # Global options, for all of the projects
 if(MSVC)
-    add_compile_options( /W4 /WX /wd4505 /wd4068 /MP /bigobj)
+    add_compile_options( /W4 /WX /wd4505 /wd4068 /MP /bigobj /Zi)
+    # Enable pdb generation in release builds.
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
 else()
     add_compile_options(-Wall -Wextra -pedantic -Werror -Wno-extra-semi -Wno-unused-function -Wno-language-extension-token -Wno-delete-non-abstract-non-virtual-dtor)
 endif()


### PR DESCRIPTION
* De-duplicate material support.
* PDBs are generated in release builds to allow debugging of crashes.
* Some small test checklist fixes.
* Changed default of m_vertexTexCoord1  to match REST api (VertexTextureCoord::Float32x2)