### PR TITLE
Disabled warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ project(Arrt)
 
 # Global options, for all of the projects
 if(MSVC)
-    add_compile_options( /W4 /WX /wd4505 /wd4068 /MP /bigobj /Zi)
+    add_compile_options( /W4 /wd4505 /wd4068 /MP /bigobj /Zi)
     # Enable pdb generation in release builds.
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")


### PR DESCRIPTION
/WX makes it impossible to use different Qt versions, due to warnings about deprecated functions. Disabling those warnings is not an option, but having them break the build is unnecessarily harsh.