### PR TITLE
Retrieve cpprest from vcpkg

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -18,8 +18,10 @@ resources:
 steps:
 - checkout: ArrtDependencies
   lfs: true
+  fetchDepth: 1
 - checkout: self
   submodules: true
+  fetchDepth: 1
 
 - task: PowerShell@2
   displayName: Generate Solution for vs2019

--- a/.pipelines/checkout_arrt_dependencies.ps1
+++ b/.pipelines/checkout_arrt_dependencies.ps1
@@ -51,7 +51,7 @@ $tokenBytes = [System.Text.UTF8Encoding]::UTF8.GetBytes($tokenWithUserName)
 $encoded = [System.Convert]::ToBase64String($tokenBytes)
 $headerValue = "Basic " + $encoded
 
-&git.exe -c http.$RepoUrl.extraheader="Authorization: $headerValue" clone $RepoUrl --verbose --quiet --branch $BranchName --recurse-submodules $RepoFolder
+&git.exe -c http.$RepoUrl.extraheader="Authorization: $headerValue" clone $RepoUrl --verbose --quiet --branch $BranchName --recurse-submodules $RepoFolder --depth=1
 
 if ($LASTEXITCODE -ne 0)
 {

--- a/ArrtSource/App/AppWindow.cpp
+++ b/ArrtSource/App/AppWindow.cpp
@@ -230,7 +230,7 @@ void ArrtAppWindow::OnUpdateStatusBar()
         case StorageConnectionStatus::Authenticated:
             if (m_numFileUploads > 0)
             {
-                m_statusStorageAccount->setText(QString("<html><head/><body><p>Storage Account: <span style=\"color:#ffaa00;\">Uploading %1 files: %2%</span></p></body></html>").arg(m_numFileUploads).arg(m_fileUploadPercentage * 100.0, 0, 'g', 2));
+                m_statusStorageAccount->setText(QString("<html><head/><body><p>Storage Account: <span style=\"color:#ffaa00;\">Uploading %1 files: %2%</span></p></body></html>").arg(m_numFileUploads).arg(m_fileUploadPercentage * 100.0, 0, 'f', 2));
             }
             else
             {

--- a/ArrtSource/ArrtVersion.h
+++ b/ArrtSource/ArrtVersion.h
@@ -2,7 +2,7 @@
 
 // Version information which is going to be exposed in the output executable
 
-#define ARRT_VERSION "2.0.1"
+#define ARRT_VERSION "2.1.0"
 
 #define VER_COMPANY "Microsoft Corporation"
 #define VER_PRODUCTNAME "Azure Remote Rendering Toolkit"

--- a/ArrtSource/Conversion/ConversionManager.cpp
+++ b/ArrtSource/Conversion/ConversionManager.cpp
@@ -241,7 +241,7 @@ bool ConversionManager::StartConversionInternal()
     {
         QString advancedOptionsJSON = conv.m_options.ToJSON();
 
-        QFileInfo assetFile = conv.m_sourceAsset;
+        QFileInfo assetFile(conv.m_sourceAsset);
         QString settingsFileName = assetFile.path() + "/" + assetFile.completeBaseName() + ".ConversionSettings.json";
 
         QString errorMsg;

--- a/ArrtSource/Storage/FileUploader.cpp
+++ b/ArrtSource/Storage/FileUploader.cpp
@@ -85,8 +85,8 @@ void FileUploader::NotifyBytesRead(int64_t bytes)
 
     const int remainingFiles = m_remainingFiles;
 
-    int64_t read = m_bytesRead;
-    int64_t total = m_totalBytesToRead;
+    const int64_t read = m_bytesRead;
+    const int64_t total = m_totalBytesToRead;
     const float percentage = (total > 0) ? (double)read / (double)total : 1.0;
 
     QMetaObject::invokeMethod(QApplication::instance(), [this, remainingFiles, percentage]()
@@ -245,8 +245,8 @@ void FileUploader::UploadFileInternalSync(const QDir& sourceRootDirectory, const
 
     const int remainingFiles = m_remainingFiles.fetch_sub(1) - 1;
 
-    int64_t read = m_bytesRead;
-    int64_t total = m_totalBytesToRead;
+    const int64_t read = m_bytesRead;
+    const int64_t total = m_totalBytesToRead;
     const float percentage = (total > 0) ? (double)read / (double)total : 1.0;
 
     QMetaObject::invokeMethod(QApplication::instance(), [this, remainingFiles, percentage]()

--- a/ArrtSource/Storage/FileUploader.h
+++ b/ArrtSource/Storage/FileUploader.h
@@ -2,9 +2,9 @@
 
 #include <atomic>
 #include <functional>
+#include <qcontainerfwd.h>
 
 class QDir;
-class QStringList;
 class QString;
 class StorageAccount;
 

--- a/ArrtSource/Utils/TimeValidator.cpp
+++ b/ArrtSource/Utils/TimeValidator.cpp
@@ -13,7 +13,11 @@ void TimeValidator::fixup(QString& input) const
 
 QValidator::State TimeValidator::validate(QString& input, int& /*pos*/) const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QStringList numbers = input.split(tr(":"), Qt::SplitBehaviorFlags::SkipEmptyParts);
+#else
     QStringList numbers = input.split(tr(":"), QString::SkipEmptyParts);
+#endif
 
     if (numbers.size() > 2)
     {
@@ -67,7 +71,11 @@ QString TimeValidator::minutesToString(int minutes)
 int TimeValidator::stringToMinutes(const QString& s)
 {
     int minutes = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QStringList numbers = s.split(tr(":"), Qt::SplitBehaviorFlags::SkipEmptyParts);
+#else
     QStringList numbers = s.split(tr(":"), QString::SkipEmptyParts);
+#endif
     if (numbers.size() >= 2)
     {
         minutes += numbers[numbers.size() - 2].toInt() * 60;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required (VERSION 3.12)
 
-set( CFG $<IF:$<CONFIG:Debug>,DEBUG,RELEASE> )
-set( POSTFIX $<$<CONFIG:Debug>:d> )
-
-set(LIB_REST_ROOT "${CMAKE_BINARY_DIR}/packages/cpprestsdk.v140.windesktop.msvcstl.dyn.rt-dyn.2.9.1")
-set(LIB_REST_NAME "${LIB_REST_ROOT}/lib/native/v140/windesktop/msvcstl/dyn/rt-dyn/x64/${CFG}/cpprest140${POSTFIX}_2_9")
+set( CMAKE_CONFIGURATION_TYPES Debug;Release )
 
 if ("$ENV{LIB_ARR_USE_LOCAL}" STREQUAL "true")
     set(LIB_ARR_BIN $<IF:$<CONFIG:Debug>,$ENV{LIB_ARR_BIN_DEBUG},$ENV{LIB_ARR_BIN_RELEASE}>)
@@ -32,15 +28,7 @@ if (NOT "$ENV{NUGET_RESTORE}" STREQUAL "false")
     endif()
 endif()
 
-# forward version from build pipeline
-#if(DEFINED ENV{ARRT_VERSION})
-#    set(ARRT_VERSION $ENV{ARRT_VERSION})
-#    message("ARRT Version = ${ARRT_VERSION}")
-#    add_definitions(-DARRT_VERSION="${ARRT_VERSION}")
-#    set(CMAKE_SUPPRESS_REGENERATION true)
-#endif()
 
-set( CMAKE_CONFIGURATION_TYPES Debug;Release )
 
 #################
 # ARRT SOLUTION
@@ -48,16 +36,12 @@ set( CMAKE_CONFIGURATION_TYPES Debug;Release )
 project(Arrt)
 
 # Global options, for all of the projects
-if(MSVC)
-    add_compile_options( /W4 /wd4505 /wd4068 /MP /bigobj /Zi)
+add_compile_options( /W4 /wd4505 /wd4068 /MP /bigobj /Zi)
  
-	# Enable pdb generation in release builds.
-    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror -Wno-extra-semi -Wno-unused-function -Wno-language-extension-token -Wno-delete-non-abstract-non-virtual-dtor)
-endif()
+# Enable pdb generation in release builds.
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -72,11 +56,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-
-find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
 
 ###################
 # ARRT Executable
@@ -84,13 +68,7 @@ find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
 set (TARGET "Arrt")
 
 set (SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/ArrtSource")
-file(GLOB SOURCE_LIST LIST_DIRECTORIES false "${SOURCE_ROOT}/*.cpp" "${SOURCE_ROOT}/*.h" "${SOURCE_ROOT}/Resources/*.qrc" "${SOURCE_ROOT}/Resources/*.ico")
-
-# add the resource file only if it's visual c++, just as a temporary workaround to avoid LLVM errors with the VERSIONINFO parsing
-if(MSVC)
-    file( GLOB NEW_FILES "${SOURCE_ROOT}/Resources/*.rc" )
-    set(SOURCE_LIST ${SOURCE_LIST} ${NEW_FILES})
-endif()
+file(GLOB SOURCE_LIST LIST_DIRECTORIES false "${SOURCE_ROOT}/*.cpp" "${SOURCE_ROOT}/*.h" "${SOURCE_ROOT}/Resources/*.qrc" "${SOURCE_ROOT}/Resources/*.ico" "${SOURCE_ROOT}/Resources/*.rc")
     
 set(SRC_DIRS
 	App
@@ -124,19 +102,18 @@ add_custom_command(
 add_custom_command(
     TARGET ${TARGET} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${LIB_REST_NAME}.dll
         ${LIB_ARR_BIN}/RemoteRenderingClient.dll
         ${LIB_ARR_BIN}/Microsoft.Holographic.HybridRemoting.dll
         $<TARGET_FILE_DIR:${TARGET}>
 )
 
+find_package(cpprestsdk CONFIG REQUIRED)
+target_link_libraries(${TARGET} PRIVATE cpprestsdk::cpprest)
+
 target_include_directories(${TARGET} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ArrtSource")
 target_link_libraries(${TARGET} PUBLIC d3d11.lib DXGI.lib)
 
 target_link_libraries(${TARGET} PUBLIC Qt5::Core Qt5::Widgets Qt5::Gui)
-
-target_link_libraries(${TARGET} PUBLIC "${LIB_REST_NAME}.lib")
-target_include_directories(${TARGET} PUBLIC "${LIB_REST_ROOT}/build/native/include")
 
 target_link_libraries(${TARGET} PUBLIC "${LIB_ARR_LIB}/RemoteRenderingClient.lib")
 target_include_directories(${TARGET} PUBLIC ${LIB_ARR_INCLUDE})
@@ -151,6 +128,9 @@ if (USE_NEW_AZURE_STORAGE_SDK)
     target_compile_definitions(${TARGET} PUBLIC NEW_STORAGE_SDK=1)
 
 else()
+
+    set( CFG $<IF:$<CONFIG:Debug>,DEBUG,RELEASE> )
+    set( POSTFIX $<$<CONFIG:Debug>:d> )
 
     set(LIB_BLOB_ROOT "${CMAKE_BINARY_DIR}/packages/Microsoft.Azure.Storage.CPP.v140.5.0.0")
     set(LIB_BLOB_NAME "${LIB_BLOB_ROOT}/lib/native/v140/x64/${CFG}/wastorage${POSTFIX}")

--- a/GenerateSolution.ps1
+++ b/GenerateSolution.ps1
@@ -47,8 +47,18 @@ if ((Test-Path -Path $VcpkgPath) -eq $false) {
 	# could check out a fixed commit, but we'll just try latest for now
 }
 
+# bootstrap vcpkg
 &$VcpkgPath\bootstrap-vcpkg.bat
+
+# get Azure Storage SDK through vcgpk
 &$VcpkgPath\vcpkg.exe install azure-storage-blobs-cpp:x64-windows 
+
+if (!$?) {
+	throw "Vcpkg error $LASTEXITCODE, see log above."
+}
+
+# get CppRest SDK through vcgpk
+&$VcpkgPath\vcpkg.exe install cpprestsdk:x64-windows
 
 if (!$?) {
 	throw "Vcpkg error $LASTEXITCODE, see log above."

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cpprestsdk.v140.windesktop.msvcstl.dyn.rt-dyn" version="2.9.1" targetFramework="native" />
   <package id="Microsoft.Azure.RemoteRendering.Cpp" version="1.0.36" targetFramework="native" />
   <!-- not in use anymore <package id="Microsoft.Azure.Storage.CPP.v140" version="5.0.0" targetFramework="native" /> -->
 </packages>


### PR DESCRIPTION
The cpprest dependency is now pulled from vcpkg, rather than a Nuget package.
This also upgrades the cpprest version.