### PR TITLE
Several conversion UI fixes

### DIFF
--- a/ArrtSource/ArrtVersion.h
+++ b/ArrtSource/ArrtVersion.h
@@ -2,7 +2,7 @@
 
 // Version information which is going to be exposed in the output executable
 
-#define ARRT_VERSION "2.3.0"
+#define ARRT_VERSION "2.3.1"
 
 #define VER_COMPANY "Microsoft Corporation"
 #define VER_PRODUCTNAME "Azure Remote Rendering Toolkit"

--- a/ArrtSource/Conversion/Conversion.h
+++ b/ArrtSource/Conversion/Conversion.h
@@ -84,7 +84,7 @@ struct ConversionOptions
     VertexVector m_vertexTangent = VertexVector::ByteSx4N;
     VertexVector m_vertexBinormal = VertexVector::ByteSx4N;
     VertexTextureCoord m_vertexTexCoord0 = VertexTextureCoord::Float32x2;
-    VertexTextureCoord m_vertexTexCoord1 = VertexTextureCoord::Float32x2;
+    VertexTextureCoord m_vertexTexCoord1 = VertexTextureCoord::None;
 
     QString ToJSON() const;
 };

--- a/ArrtSource/Conversion/ConversionManager.h
+++ b/ArrtSource/Conversion/ConversionManager.h
@@ -30,6 +30,9 @@ public:
     /// Changes the currently selected conversion.
     void SetSelectedConversion(int selected);
 
+    /// Returns the index of the selected conversion.
+    int GetSelectedConversionIndex() const { return m_selectedConversion; }
+
     /// Whether the selected conversion is editable, e.g. a not yet started one.
     bool IsEditableSelected() const;
 

--- a/ArrtSource/Conversion/UI/ConversionTab.cpp
+++ b/ArrtSource/Conversion/UI/ConversionTab.cpp
@@ -6,7 +6,6 @@ void ArrtAppWindow::on_ConversionList_currentRowChanged(int row)
 {
     RetrieveConversionOptions();
     m_conversionManager->SetSelectedConversion(row);
-    UpdateConversionPane();
 }
 
 static QString SecToString(uint32_t sec)
@@ -158,7 +157,7 @@ void ArrtAppWindow::UpdateConversionPane()
         SelectSourceButton->setEnabled(allowEditing);
         SelectOutputFolderButton->setEnabled(allowEditing);
         SelectInputFolderButton->setEnabled(allowEditing && !conv.m_sourceAsset.isEmpty());
-        OptionsArea->setEnabled(allowEditing);
+        scrollAreaWidgetContents->setEnabled(allowEditing);
 
         // enable or disable the start conversion button depending on whether enough data is set
         StartConversionButton->setEnabled(allowEditing && !conv.m_sourceAsset.isEmpty() && !conv.m_outputFolderContainer.isEmpty());
@@ -235,12 +234,16 @@ void ArrtAppWindow::UpdateConversionPane()
         TexCoord0Combo->setCurrentIndex((int)opt.m_vertexTexCoord0);
         TexCoord1Combo->setCurrentIndex((int)opt.m_vertexTexCoord1);
     }
+
+    ConversionList->setCurrentRow(m_conversionManager->GetSelectedConversionIndex());
 }
 
 void ArrtAppWindow::RetrieveConversionOptions()
 {
     if (!m_conversionManager->IsEditableSelected())
         return;
+
+    m_conversionManager->blockSignals(true);
 
     m_conversionManager->SetConversionName(ConversionNameInput->text());
 
@@ -268,6 +271,8 @@ void ArrtAppWindow::RetrieveConversionOptions()
     opt.m_vertexTexCoord1 = (VertexTextureCoord)TexCoord1Combo->currentIndex();
 
     m_conversionManager->SetConversionAdvancedOptions(opt);
+
+    m_conversionManager->blockSignals(false);
 }
 
 void ArrtAppWindow::on_ConversionOptionsCheckbox_stateChanged(int state)


### PR DESCRIPTION
* Prevent accidental reset of advanced options
* Select the correct conversion after the recent list is retrieved
* TexCoord1 now defaults to 'none'