### PR TITLE
Add option to mock ARRT user interface

### DIFF
--- a/ArrtSource/App/AppWindow.cpp
+++ b/ArrtSource/App/AppWindow.cpp
@@ -40,7 +40,7 @@ ArrtAppWindow::ArrtAppWindow(const ArrtCommandLineOptions& cmdLineOptions)
     m_arrSettings = std::make_unique<ArrSettings>();
     m_arrSettings->LoadSettings();
 
-    if (cmdLineOptions.mock)
+    if (cmdLineOptions.m_mock)
     {
         m_arrAclient = std::make_unique<ArrAccountMock>();
         m_storageAccount = std::make_unique<StorageAccountMock>();

--- a/ArrtSource/App/AppWindow.h
+++ b/ArrtSource/App/AppWindow.h
@@ -15,13 +15,18 @@ class ScenegraphModel;
 class QProgressBar;
 class ArrSettings;
 
+struct ArrtCommandLineOptions
+{
+    bool mock;
+};
+
 /// The applications main window
 class ArrtAppWindow : public QMainWindow, Ui_AppWindow
 {
     Q_OBJECT
 
 public:
-    ArrtAppWindow();
+    ArrtAppWindow(const ArrtCommandLineOptions& cmdLineOptions);
     ~ArrtAppWindow();
 
 private Q_SLOTS:

--- a/ArrtSource/App/AppWindow.h
+++ b/ArrtSource/App/AppWindow.h
@@ -17,7 +17,7 @@ class ArrSettings;
 
 struct ArrtCommandLineOptions
 {
-    bool mock;
+    bool m_mock = false;
 };
 
 /// The applications main window

--- a/ArrtSource/ArrtMain.cpp
+++ b/ArrtSource/ArrtMain.cpp
@@ -274,31 +274,31 @@ static void SetStyleSheet(QApplication* /*app*/)
 /// Convert command line arguments from WinMain syntax to argc, argv
 struct CommandLineArguments
 {
-    int argc;
-    char** argv;
+    int m_argc;
+    char** m_argv;
 
     CommandLineArguments()
     {
-        LPWSTR* szArglist = CommandLineToArgvW(GetCommandLineW(), &argc);
-        argv = new char*[argc];
+        LPWSTR* szArglist = CommandLineToArgvW(GetCommandLineW(), &m_argc);
+        m_argv = new char*[m_argc];
 
-        for (int i = 0; i < argc; i++)
+        for (int i = 0; i < m_argc; i++)
         {
             size_t len = wcslen(szArglist[i]);
-            argv[i] = new char[len + 1];
-            argv[i][len] = '\0';
-            wcstombs(argv[i], szArglist[i], len);
+            m_argv[i] = new char[len + 1];
+            m_argv[i][len] = '\0';
+            wcstombs(m_argv[i], szArglist[i], len);
         }
     }
 
     ~CommandLineArguments()
-	{
-        for (int i = 0; i < argc; i++)
+    {
+        for (int i = 0; i < m_argc; i++)
         {
-			delete[] argv[i];
-		}
-		delete[] argv;
-	}
+            delete[] m_argv[i];
+        }
+        delete[] m_argv;
+    }
 };
 
 ArrtCommandLineOptions GetCommandLineOptions(const QApplication& app)
@@ -314,7 +314,7 @@ ArrtCommandLineOptions GetCommandLineOptions(const QApplication& app)
     parser.process(app);
 
     ArrtCommandLineOptions cmdLineOptions;
-    cmdLineOptions.mock = parser.isSet(mockOption);
+    cmdLineOptions.m_mock = parser.isSet(mockOption);
     return cmdLineOptions;
 }
 
@@ -333,7 +333,7 @@ int WinMain(HINSTANCE, HINSTANCE, char*, int)
     QCoreApplication::setApplicationVersion(ARRT_VERSION);
 
     CommandLineArguments cmdLineArgs;
-    QApplication app(cmdLineArgs.argc, cmdLineArgs.argv);
+    QApplication app(cmdLineArgs.m_argc, cmdLineArgs.m_argv);
 
     SetStyleSheet(&app);
     auto cmdLineOptions = GetCommandLineOptions(app);

--- a/ArrtSource/Conversion/ConversionManager.h
+++ b/ArrtSource/Conversion/ConversionManager.h
@@ -8,6 +8,7 @@
 
 class StorageAccount;
 class ArrAccount;
+class ArrAccountMock;
 
 /// Manages interactions with the model conversion service
 class ConversionManager : public QObject
@@ -15,7 +16,8 @@ class ConversionManager : public QObject
     Q_OBJECT
 
 public:
-    ConversionManager(StorageAccount* storageAccount, ArrAccount* arrClient);
+    ConversionManager();
+    ConversionManager(StorageAccount* storageAccount, ArrAccount* arrAccount);
     ~ConversionManager();
 
     /// Returns all recent conversions, both running and finished ones.
@@ -52,19 +54,31 @@ Q_SIGNALS:
     void ConversionFailed();
     void ConversionSucceeded();
 
-private Q_SLOTS:
-    void OnCheckConversions();
+protected Q_SLOTS:
+    virtual void OnCheckConversions();
 
-private:
+protected:
+    virtual void SetupConversion(Conversion&);
     bool StartConversionInternal();
     void SetConversionStatus(int conversionIdx, RR::Status status, RR::ApiHandle<RR::ConversionPropertiesResult> result);
     void GetCurrentConversionsResult(RR::Status status, RR::ApiHandle<RR::ConversionPropertiesArrayResult> result);
 
     StorageAccount* m_storageAccount = nullptr;
-    ArrAccount* m_arrClient = nullptr;
+    ArrAccount* m_arrAccount = nullptr;
     QTimer m_checkConversionStateTimer;
     QTimer m_updateConversionListTimer;
 
     int m_selectedConversion = 0;
     std::deque<Conversion> m_conversions;
+};
+
+class ConversionManagerMock : public ConversionManager
+{
+public:
+    ConversionManagerMock(StorageAccount* storageAccount);
+
+private: 
+    void OnCheckConversions() override;
+    void SetupConversion(Conversion& conv) override;
+    void CreateMockConversion(Conversion& conv);
 };

--- a/ArrtSource/Rendering/ArrAccount.cpp
+++ b/ArrtSource/Rendering/ArrAccount.cpp
@@ -246,7 +246,6 @@ void ArrAccount::GetCurrentRenderingSessionsResult(RR::ApiHandle<RR::RemoteRende
     }
 }
 
-
 void ArrAccount::DisconnectFromArrAccount()
 {
     if (m_rrClient == nullptr)
@@ -315,4 +314,14 @@ void ArrAccount::GetAvailableAccountDomains(std::vector<ArrAccountDomainInfo>& d
 
     std::sort(domains.begin(), domains.end(), [](const ArrAccountDomainInfo& lhs, const ArrAccountDomainInfo& rhs)
               { return lhs.m_name < rhs.m_name; });
+}
+
+void ArrAccountMock::ConnectToArrAccount()
+{
+    SetConnectionStatus(ArrConnectionStatus::Authenticated);
+}
+
+void ArrAccountMock::DisconnectFromArrAccount()
+{
+    SetConnectionStatus(ArrConnectionStatus::NotAuthenticated);
 }

--- a/ArrtSource/Rendering/ArrAccount.h
+++ b/ArrtSource/Rendering/ArrAccount.h
@@ -38,7 +38,7 @@ Q_SIGNALS:
 
 public:
     ArrAccount();
-    ~ArrAccount();
+    virtual ~ArrAccount();
 
     RR::ApiHandle<RR::RemoteRenderingClient>& GetClient() { return m_rrClient; }
 
@@ -51,15 +51,15 @@ public:
     QString GetAccountDomain() const { return m_accountDomain; }
     QString GetRegion() const { return m_region; }
 
-    void ConnectToArrAccount();
-    void DisconnectFromArrAccount();
+    virtual void ConnectToArrAccount();
+    virtual void DisconnectFromArrAccount();
 
     ArrConnectionStatus GetConnectionStatus() const { return m_connectionStatus; }
 
     void GetAvailableRegions(std::vector<ArrRegionInfo>& regions);
     void GetAvailableAccountDomains(std::vector<ArrAccountDomainInfo>& domains);
 
-private:
+protected:
     static void SanitizeSettings(QString& accountId, QString& accountKey, QString& accountDomain, QString& region);
     void SetConnectionStatus(ArrConnectionStatus newStatus);
     void GetCurrentRenderingSessionsResult(RR::ApiHandle<RR::RemoteRenderingClient> client, RR::Status status, RR::ApiHandle<RR::RenderingSessionPropertiesArrayResult> result);
@@ -81,4 +81,12 @@ private:
     std::vector<ArrAccountDomainInfo> m_customAccountDomains;
 
     RR::event_token m_messageLoggedToken;
+};
+
+/// Mock implementation of ArrAccount to run ARRT UI without account credentials.
+class ArrAccountMock : public ArrAccount
+{
+public:
+    void ConnectToArrAccount() override;
+    void DisconnectFromArrAccount() override;
 };

--- a/ArrtSource/Rendering/ArrConnectionLogic.cpp
+++ b/ArrtSource/Rendering/ArrConnectionLogic.cpp
@@ -144,6 +144,13 @@ void ArrConnectionLogic::OpenExistingSession(RR::ApiHandle<RR::RemoteRenderingCl
     client->OpenRenderingSessionAsync(sessionID.toStdString(), callOpenOrCreateSessionResult);
 }
 
+void ArrConnectionLogic::MockNewSession()
+{
+    m_currentState = State::RuntimeConnected;
+    Q_EMIT ConnectionStateChanged();
+    return;
+}
+
 void ArrConnectionLogic::CloseSession(bool keepRunning)
 {
     assert(IsConnectionStoppable());
@@ -155,7 +162,7 @@ void ArrConnectionLogic::CloseSession(bool keepRunning)
 
     DisconnectFromRuntime();
 
-    if (!keepRunning)
+    if (!keepRunning && m_arrSession)
     {
         auto onStop = [](RR::Status, RR::ApiHandle<RR::SessionContextResult>) { /* we could retrieve details here, but there is really no reason why stopping a session should fail, other than if we tried to stop an already stopped or expired session */ };
         m_arrSession->StopAsync(onStop);
@@ -512,5 +519,8 @@ void ArrConnectionLogic::DisconnectFromRuntime()
         m_messageLoggedToken.invalidate();
     }
 
-    m_arrSession->Disconnect();
+    if (m_arrSession)
+    {
+        m_arrSession->Disconnect();
+    }
 }

--- a/ArrtSource/Rendering/ArrConnectionLogic.h
+++ b/ArrtSource/Rendering/ArrConnectionLogic.h
@@ -50,6 +50,7 @@ public:
 
     void CreateNewSession(RR::ApiHandle<RR::RemoteRenderingClient>& client, const RR::RenderingSessionCreationOptions& info);
     void OpenExistingSession(RR::ApiHandle<RR::RemoteRenderingClient>& client, const QString& sessionID);
+    void MockNewSession();
     void CloseSession(bool keepRunning);
 
     void CleanupSession();

--- a/ArrtSource/Rendering/ArrSession.cpp
+++ b/ArrtSource/Rendering/ArrSession.cpp
@@ -77,9 +77,9 @@ void ArrSession::OnDeinitGrahpcs()
     Q_EMIT ModelLoadProgressChanged();
 }
 
-ArrSession::ArrSession(ArrAccount* arrClient, SceneState* sceneState)
+ArrSession::ArrSession(ArrAccount* arrAccount, SceneState* sceneState)
 {
-    m_arrAccount = arrClient;
+    m_arrAccount = arrAccount;
     m_sceneState = sceneState;
 
     connect(sceneState, &SceneState::SceneRefreshed, this, [this]()
@@ -118,11 +118,21 @@ QString ArrSession::GetSessionID() const
 
 void ArrSession::CreateSession(const RR::RenderingSessionCreationOptions& info)
 {
+    if (m_arrAccount->GetClient() == nullptr)
+    {
+        m_ConnectionLogic.MockNewSession();
+        return;
+    }
     m_ConnectionLogic.CreateNewSession(m_arrAccount->GetClient(), info);
 }
 
 void ArrSession::OpenSession(const QString& sessionID)
 {
+    if (m_arrAccount->GetClient() == nullptr)
+    {
+        m_ConnectionLogic.MockNewSession();
+        return;
+    }
     m_ConnectionLogic.OpenExistingSession(m_arrAccount->GetClient(), sessionID);
 }
 
@@ -449,6 +459,7 @@ bool ArrSession::LoadModel(const QString& modelName, const char* assetSAS)
 
     RR::LoadModelFromSasOptions params;
     params.ModelUri = assetSAS;
+
     api->LoadModelFromSasAsync(params, onModelLoaded, onModelLoadingProgress);
 
     return true;

--- a/ArrtSource/Rendering/ArrSession.h
+++ b/ArrtSource/Rendering/ArrSession.h
@@ -17,6 +17,7 @@ namespace Microsoft::Azure::RemoteRendering
 
 
 class ArrAccount;
+class ArrAccountMock;
 class QTimer;
 class SceneState;
 
@@ -67,7 +68,7 @@ private Q_SLOTS:
     void OnDeinitGrahpcs();
 
 public:
-    ArrSession(ArrAccount* arrClient, SceneState* sceneState);
+    ArrSession(ArrAccount* arrAccount, SceneState* sceneState);
     ~ArrSession();
 
     const ArrConnectionLogic& GetConnectionState() const { return m_ConnectionLogic; }

--- a/ArrtSource/Rendering/UI/SceneState.cpp
+++ b/ArrtSource/Rendering/UI/SceneState.cpp
@@ -286,7 +286,10 @@ void SceneState::PickEntity(int x, int y)
         Q_EMIT PickedEntity();
     };
 
-    m_client->RayCastQueryAsync(rc, onRaycastResult);
+    if (m_client)
+    {
+        m_client->RayCastQueryAsync(rc, onRaycastResult);
+    }
 }
 
 void SceneState::RenderTo(ID3D11RenderTargetView* renderTarget)

--- a/ArrtSource/Storage/StorageAccount.cpp
+++ b/ArrtSource/Storage/StorageAccount.cpp
@@ -289,6 +289,9 @@ void StorageAccount::ListContainers(std::vector<QString>& containers) const
 
 void StorageAccount::ListBlobDirectory(const QString& containerName, const QString& prefixPath, std::vector<StorageBlobInfo>& directories, std::vector<StorageBlobInfo>& files) const
 {
+    if (m_azStorageServiceClient == nullptr)
+        return;
+
     const QString cacheKey = containerName + "##" + prefixPath;
 
     auto cacheIt = m_cachedBlobs.find(cacheKey);
@@ -380,4 +383,24 @@ QString StorageAccount::CreateSasURL(const QString& containerName, const QString
     uriAndSas.append(sas);
 
     return uriAndSas;
+}
+
+void StorageAccountMock::ConnectToStorageAccount()
+{
+    m_connectionStatus = StorageConnectionStatus::Authenticated;
+}
+
+bool StorageAccountMock::CreateContainer(const QString&, QString&)
+{
+    return true;
+}
+
+bool StorageAccountMock::DeleteContainer(const QString&, QString&)
+{
+    return true;
+}
+
+bool StorageAccountMock::CreateTextItem(const QString&, const QString&, const QString&, QString&)
+{
+    return true;
 }

--- a/ArrtSource/Storage/UI/StorageBrowserWidget.cpp
+++ b/ArrtSource/Storage/UI/StorageBrowserWidget.cpp
@@ -335,7 +335,7 @@ void StorageBrowserWidget::UploadItems(const QStringList& files)
 
     if (auto file_uploader = m_storageAccount->GetFileUploader(); file_uploader != nullptr)
     {
-        m_storageAccount->GetFileUploader()->UploadFilesAsync(rootDirectory, toUpload, GetSelectedContainer(), dstFolder);
+        file_uploader->UploadFilesAsync(rootDirectory, toUpload, GetSelectedContainer(), dstFolder);
     }
 }
 

--- a/ArrtSource/Storage/UI/StorageBrowserWidget.cpp
+++ b/ArrtSource/Storage/UI/StorageBrowserWidget.cpp
@@ -333,7 +333,10 @@ void StorageBrowserWidget::UploadItems(const QStringList& files)
         return;
     }
 
-    m_storageAccount->GetFileUploader()->UploadFilesAsync(rootDirectory, toUpload, GetSelectedContainer(), dstFolder);
+    if (auto file_uploader = m_storageAccount->GetFileUploader(); file_uploader != nullptr)
+    {
+        m_storageAccount->GetFileUploader()->UploadFilesAsync(rootDirectory, toUpload, GetSelectedContainer(), dstFolder);
+    }
 }
 
 void StorageBrowserWidget::on_UploadFileButton_clicked()


### PR DESCRIPTION
In order to aid development and testing of the ARRT interface, a command-line argument "--mock" was added which mocks the connection to an ARR account and a storage account. This allows users to test the user interface of the app without needing to connect to any account.