### PR TITLE
Improvements around session creation; warn user of invalid bounding box

### DIFF
--- a/ArrtSource/App/SettingsDlg.cpp
+++ b/ArrtSource/App/SettingsDlg.cpp
@@ -81,7 +81,8 @@ void SettingsDlg::on_Buttons_rejected()
 
 void SettingsDlg::on_TestArr_clicked()
 {
-    ApplyArr();
+    if (!ApplyArr())
+        return;
 
     if (ArrAccountID->text().isEmpty())
     {
@@ -209,9 +210,13 @@ void SettingsDlg::on_ProfileDropDown_currentIndexChanged(int index)
     PushProfile();
 }
 
-void SettingsDlg::ApplyArr()
+bool SettingsDlg::ApplyArr()
 {
-    m_arrClient->SetSettings(ArrAccountID->text(), ArrAccountKey->text(), ArrAccountDomain->currentData().toString(), ArrRegion->currentData().toString());
+    if (!m_arrClient->SetSettings(ArrAccountID->text(), ArrAccountKey->text(), ArrAccountDomain->currentData().toString(), ArrRegion->currentData().toString()))
+    {
+        QMessageBox::warning(this, "ARR account settings", "Cannot change ARR account settings while a session is running.", QMessageBox::Ok);
+        return false;
+    }
     m_arrClient->ConnectToArrAccount();
 }
 

--- a/ArrtSource/App/SettingsDlg.h
+++ b/ArrtSource/App/SettingsDlg.h
@@ -36,7 +36,7 @@ private Q_SLOTS:
     void on_ProfileDropDown_currentIndexChanged(int index);
 
 private:
-    void ApplyArr();
+    bool ApplyArr();
     void ApplyStorage();
     void FillProfiles();
     void SetActiveProfile(const QString& name);

--- a/ArrtSource/Rendering/ArrAccount.cpp
+++ b/ArrtSource/Rendering/ArrAccount.cpp
@@ -141,12 +141,19 @@ void ArrAccount::SanitizeSettings(QString& accountId, QString& accountKey, QStri
         accountDomain.chop(1);
 }
 
-void ArrAccount::SetSettings(QString accountId, QString accountKey, QString accountDomain, QString region)
+bool ArrAccount::SetSettings(QString accountId, QString accountKey, QString accountDomain, QString region)
 {
     SanitizeSettings(accountId, accountKey, accountDomain, region);
 
     if (m_accountId == accountId && m_accountKey == accountKey && m_accountDomain == accountDomain && m_region == region)
-        return;
+    {
+        return true;
+    }
+
+    if (m_blockChanges)
+    {
+        return false;
+    }
 
     m_accountId = accountId;
     m_accountKey = accountKey;
@@ -156,6 +163,7 @@ void ArrAccount::SetSettings(QString accountId, QString accountKey, QString acco
     SaveSettings();
 
     DisconnectFromArrAccount();
+    return true;
 }
 
 void ArrAccount::SetConnectionStatus(ArrConnectionStatus newStatus)
@@ -314,6 +322,11 @@ void ArrAccount::GetAvailableAccountDomains(std::vector<ArrAccountDomainInfo>& d
 
     std::sort(domains.begin(), domains.end(), [](const ArrAccountDomainInfo& lhs, const ArrAccountDomainInfo& rhs)
               { return lhs.m_name < rhs.m_name; });
+}
+
+void ArrAccount::BlockChanges(bool block)
+{
+	m_blockChanges = block;
 }
 
 void ArrAccountMock::ConnectToArrAccount()

--- a/ArrtSource/Rendering/ArrAccount.h
+++ b/ArrtSource/Rendering/ArrAccount.h
@@ -44,7 +44,7 @@ public:
 
     bool LoadSettings();
     void SaveSettings() const;
-    void SetSettings(QString accountId, QString accountKey, QString accountDomain, QString region);
+    bool SetSettings(QString accountId, QString accountKey, QString accountDomain, QString region);
 
     QString GetAccountId() const { return m_accountId; }
     QString GetAccountKey() const { return m_accountKey; }
@@ -58,6 +58,8 @@ public:
 
     void GetAvailableRegions(std::vector<ArrRegionInfo>& regions);
     void GetAvailableAccountDomains(std::vector<ArrAccountDomainInfo>& domains);
+
+    void BlockChanges(bool block);
 
 protected:
     static void SanitizeSettings(QString& accountId, QString& accountKey, QString& accountDomain, QString& region);
@@ -81,6 +83,7 @@ protected:
     std::vector<ArrAccountDomainInfo> m_customAccountDomains;
 
     RR::event_token m_messageLoggedToken;
+    bool m_blockChanges = false;
 };
 
 /// Mock implementation of ArrAccount to run ARRT UI without account credentials.

--- a/ArrtSource/Rendering/ArrConnectionLogic.cpp
+++ b/ArrtSource/Rendering/ArrConnectionLogic.cpp
@@ -245,10 +245,13 @@ void ArrConnectionLogic::OpenOrCreateSessionResult(RR::Status status, RR::ApiHan
         qCritical(LoggingCategory::RenderingSession)
             << "Session creation failed: " << errorCode;
 
-        qDebug(LoggingCategory::RenderingSession)
-            << "Session context:\n"
-            << result->GetContext();
-
+        auto context = result->GetContext();
+        qDebug(LoggingCategory::RenderingSession) << "Error message: " << context.ErrorMessage.c_str() 
+            << "\nHttp Response Code: " << context.HttpResponseCode 
+            << "\nRequest Correlation Vector: " << context.RequestCorrelationVector.c_str() 
+            << "\nResponse Correlation Vector: " << context.ResponseCorrelationVector.c_str() 
+            << "\nResult: " << context.Result;
+            
         QMessageBox::warning(nullptr, "Session Creation Failed", "Session creation failed.\n\nSee the log for details.", QMessageBox::Ok, QMessageBox::Ok);
     }
 

--- a/ArrtSource/Rendering/ArrSession.cpp
+++ b/ArrtSource/Rendering/ArrSession.cpp
@@ -160,7 +160,7 @@ void ArrSession::CheckEntityBounds(RR::ApiHandle<RR::Entity> entity)
 {
     entity->QueryWorldBoundsAsync([this](RR::Status status, RR::Bounds bounds)
                                   {
-                                      if (status == RR::Status::OK && bounds.IsValid())
+                                      if (status == RR::Status::OK)
                                       {
                                           // pass the information to the main thread, because we want to interact with the GUI
                                           QMetaObject::invokeMethod(QApplication::instance(), [this, bounds]()
@@ -170,6 +170,12 @@ void ArrSession::CheckEntityBounds(RR::ApiHandle<RR::Entity> entity)
 
 void ArrSession::CheckEntityBoundsResult(RR::Bounds bounds)
 {
+    if (!bounds.IsValid())
+    {
+        qWarning(LoggingCategory::RenderingSession) << "The loaded model's bounding box is invalid.";
+        return;
+    }
+
     const float maxX = (float)bounds.Max.X;
     const float minX = (float)bounds.Min.X;
     const float maxY = (float)bounds.Max.Y;
@@ -180,6 +186,12 @@ void ArrSession::CheckEntityBoundsResult(RR::Bounds bounds)
     const float width = maxX - minX;
     const float height = maxY - minY;
     const float depth = maxZ - minZ;
+
+    if (width < 0 || height < 0 || depth < 0)
+    {
+        qWarning(LoggingCategory::RenderingSession) << "The loaded model's bounding box is invalid.";
+        return;
+    }
 
     const float smallSize = 0.1f;
     const float largeSize = 10.0f;

--- a/ArrtSource/Rendering/ArrSession.cpp
+++ b/ArrtSource/Rendering/ArrSession.cpp
@@ -48,6 +48,8 @@ void ArrSession::OnConnectionStateChanged()
             m_loadedModels.clear();
             m_selectedEntities.clear();
         }
+
+        m_arrAccount->BlockChanges(m_ConnectionLogic.IsConnectionActive());
     }
 
     Q_EMIT SessionStatusChanged();


### PR DESCRIPTION
- Add warning if loaded model has invalid bounding box
- Improve readability of error when session creation fails
- Don't allow user to change ARR Account settings while session is active